### PR TITLE
Editorial: Use the HTML spec's timers infrastructure for `timeout`

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,38 +314,24 @@ callback IdleRequestCallback = undefined (IdleDeadline deadline);
         <a>idle callback identifier</a>.</li>
         <li>Push <var>callback</var> to the end of <var>window</var>'s <a>list
         of idle request callbacks</a>, associated with <var>handle</var>.</li>
-        <li>Return <var>handle</var> and then continue running this algorithm
-        asynchronously.
-          <p class="note">The following steps run in parallel and queue a timer
-          similar to <code>setTimeout()</code> if the optional <code>timeout</code> property is
-          provided. From here, the idle and timeout callbacks are raced and
-          cancel each other—e.g. if the idle callback is scheduled first, then
-          it cancels the timeout callback, and vice versa.</p>
-        </li>
         <li>If the <code><dfn data-dfn-for="IdleRequestOptions">timeout</dfn>
         </code> property is present in <var>options</var> and has a positive
-        value:
+        value, then <a>run steps after a timeout</a>, given <var>window</var>,
+        "<code>requestIdleCallback-timeout</code>", <var>timeout</var>, and the
+        following step:
           <ol>
-            <li>Wait for <var>timeout</var> milliseconds.</li>
-            <li>Wait until all invocations of this algorithm, whose
-            <var>timeout</var> added to their posted time occurred before this
-            one's, have completed.</li>
-            <li>Optionally, wait a further user-agent defined length of time.
-              <p class='note'>This is intended to allow user agents to pad
-              timeouts as needed to optimise the power usage of the device. For
-              example, some processors have a low-power mode where the
-              granularity of timers is reduced; on such platforms, user agents
-              can slow timers down to fit this schedule instead of requiring
-              the processor to use the more accurate mode with its associated
-              higher power usage.</p>
-            </li>
             <li><a>Queue a task</a> on the queue associated with the idle-task
             <a>task source</a>, which performs the <a>invoke idle callback
             timeout algorithm</a>, passing <var>handle</var> and
             <var>window</var> as arguments.
             </li>
           </ol>
+          <p class="note">This queues a timer similar to
+          <code>setTimeout()</code>. The idle and timeout callbacks are raced
+          and cancel each other—e.g. if the idle callback is scheduled first,
+          then it cancels the timeout callback, and vice versa.</p>
         </li>
+        <li>Return <var>handle</var>.</li>
       </ol>
       <p class="note">{{Window/requestIdleCallback()}}
       only schedules a single callback, which will be executed during a


### PR DESCRIPTION
In whatwg/html#7349, the HTML spec factored out part of the infrastructure for `setTimeout()` into a "run steps after a timeout" algorithm for use by other specs. This change updates `requestIdleCallback()` to use that algorithm when the `timeout` property is present and positive.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/andreubotella/requestidlecallback/pull/98.html" title="Last updated on Dec 2, 2021, 12:32 PM UTC (1dbacc0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/requestidlecallback/98/a251a96...andreubotella:1dbacc0.html" title="Last updated on Dec 2, 2021, 12:32 PM UTC (1dbacc0)">Diff</a>