### PR TITLE
Refer to "get deadline time" where it's set.

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@ callback IdleRequestCallback = undefined (IdleDeadline deadline);
             <li>Pop the top <var>callback</var> from <var>window</var>'s
             <a>list of runnable idle callbacks</a>.</li>
             <li>Let <var>deadlineArg</var> be a new <a>IdleDeadline</a> whose
-            </a> is <var>getDeadline</var>.</li>
+            <a>get deadline time</a> algorithm is <var>getDeadline</var>.</li>
             <li>Call <var>callback</var> with <var>deadlineArg</var> as its
             argument. If an uncaught runtime script error occurs, then [=report the exception=].</li>
             <li>If <var>window</var>'s <a>list of runnable idle callbacks</a>


### PR DESCRIPTION
I'd initially thought it was never set to a future value, but actually the link was just missing. Apologies if I've missed other places where it's set.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/requestidlecallback/pull/103.html" title="Last updated on Dec 17, 2024, 9:33 PM UTC (b823e17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/requestidlecallback/103/feeca76...jyasskin:b823e17.html" title="Last updated on Dec 17, 2024, 9:33 PM UTC (b823e17)">Diff</a>