### PR TITLE
Intialize timeout to 0 and replace 'is present' check with comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@ partial interface Window {
 };
 
 dictionary IdleRequestOptions {
-  unsigned long timeout;
+  unsigned long timeout = 0;
 };
 
 [Exposed=Window] interface IdleDeadline {
@@ -309,9 +309,9 @@ callback IdleRequestCallback = undefined (IdleDeadline deadline);
     <section data-dfn-for="Window">
       <h2>The <dfn>requestIdleCallback()</dfn> method</h2>
       <p>When {{Window/requestIdleCallback}}<code>(|callback|, |options|)</code> is
-      invoked with a given <dfn>IdleRequestCallback</dfn>
-      and optional <dfn>IdleRequestOptions</dfn>, the user agent
-      MUST run the following steps:</p>
+      invoked with a given <dfn>IdleRequestCallback</dfn> and
+      <dfn>IdleRequestOptions</dfn>, the user agent MUST run the following
+      steps:</p>
       <ol>
         <li>Let <var>window</var> be this {{Window}} object.</li>
         <li>Increment the <var>window</var>'s <a>idle callback identifier</a>
@@ -328,9 +328,9 @@ callback IdleRequestCallback = undefined (IdleDeadline deadline);
           cancel each other—e.g. if the idle callback is scheduled first, then
           it cancels the timeout callback, and vice versa.</p>
         </li>
-        <li>If the <code><dfn data-dfn-for="IdleRequestOptions">timeout</dfn>
-        </code> property is present in <var>options</var> and has a positive
-        value:
+        <li>Let <var>timeout</var> be <var>options</var>["<code><dfn
+        data-dfn-for="IdleRequestOptions">timeout</dfn></code>"].</li>
+        <li>If <var>timeout</var> is greater than 0:
           <ol>
             <li>Wait for <var>timeout</var> milliseconds.</li>
             <li>Wait until all invocations of this algorithm, whose


### PR DESCRIPTION
Fixes #105. This doesn't change behavior since the timeout was only used if it was present and positive.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shaseley/requestidlecallback/pull/106.html" title="Last updated on Feb 6, 2026, 10:13 PM UTC (0bedab4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/requestidlecallback/106/c460478...shaseley:0bedab4.html" title="Last updated on Feb 6, 2026, 10:13 PM UTC (0bedab4)">Diff</a>